### PR TITLE
ticketList 스토어 분리 및 스크롤 페이징 데이터 초기화 처리

### DIFF
--- a/src/pages/mypages/MyTicketList.vue
+++ b/src/pages/mypages/MyTicketList.vue
@@ -23,7 +23,7 @@ import TicketCard from '@/components/mypages/TicketCard.vue';
 import Footer from '@/components/Footer.vue';
 import CancelDialog from '../../components/mypages/CancelDialog.vue';
 
-import { useTicketStore } from "@/stores/tickets.js";
+import { ticketListStore } from "@/stores/ticketList.js";
 
 export default defineComponent({
     name: 'MyTicketList',
@@ -35,7 +35,7 @@ export default defineComponent({
     },
     data() {
         return {
-            ticketStore: useTicketStore(),
+            ticketStore: ticketListStore(),
             isCancelDialogVisible: false,
             token: localStorage.getItem("accessToken"),
             nextCursor: null,
@@ -95,16 +95,16 @@ export default defineComponent({
                 this.fetchTickets(this.nextCursor);
             }
         },
-        async fetchTickets(cursor = null) {
+        async fetchTickets(cursor = null, reset = false) {
             if (this.isLoading) return;
             this.isLoading = true;
-            const newTickets = await this.ticketStore.fetchTickets(cursor);
+            const newTickets = await this.ticketStore.fetchTickets(cursor, reset);
             this.nextCursor = this.ticketStore.getNextCursor();
             this.isLoading = false;
         },
     },
     mounted() {
-        this.fetchTickets();
+        this.fetchTickets(null, true);
         this.setupObserver();
     },
     beforeUnmount() {
@@ -124,6 +124,13 @@ body {
     overflow: auto;
     padding: 10px;
     top: 37px;
+    scrollbar-width: none;
+    /* Firefox */
+    -ms-overflow-style: none;
+}
+
+.ticketContainer::-webkit-scrollbar {
+    display: none;
 }
 
 .loading-spinner {

--- a/src/stores/ticketList.js
+++ b/src/stores/ticketList.js
@@ -1,0 +1,39 @@
+import axios from "axios";
+import { defineStore } from "pinia";
+
+export const ticketListStore = defineStore("ticketList", {
+  state: () => ({
+    nextCursor: null,
+    tickets: [],
+  }),
+  actions: {
+    async fetchTickets(cursor = null, reset = false) {
+      try {
+        const token = localStorage.getItem("accessToken");
+
+        const url = cursor
+          ? `http://localhost:8080/api/tickets?cursor=${cursor}`
+          : `http://localhost:8080/api/tickets`;
+        const response = await axios.get(url, {
+          headers: {
+            Authorization: `Bearer ${token}`,
+          },
+        });
+        const { result } = response.data;
+
+        if (reset) {
+          this.tickets = [];
+        }
+
+        this.tickets.push(...result.data);
+        this.nextCursor = result.nextCursor;
+        return result.data;
+      } catch (error) {
+        console.error("티켓을 불러오는 중 오류 발생:", error);
+      }
+    },
+    getNextCursor() {
+      return this.nextCursor;
+    },
+  },
+});


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)
* 기능 추가 상세 설명 필요시 작성하기
  
  - [ ] 기능 추가
  - [ ] 기능 삭제
  - [x] 버그 수정
  - [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
ex) feature/myTicketList/chs -> dev

### 변경 사항
- 나의 예매 내역 화면에서 사용하는 별도의 ticketList 스토어로 분리
- 스크롤 css를 hidden 처리하여 스크롤바 숨김
- 나의 예매 내역 화면 진입 시 티켓 데이터 초기화 기능 추가

### 테스트 결과
ex) 베이스 브랜치에 포함되기 위한 코드는 모두 정상적으로 동작해야 합니다. 결과물에 대한 스크린샷, GIF, 혹은 라이브 데모가 가능하도록 샘플API를 첨부할 수도 있습니다.
